### PR TITLE
Add desc field to ABI schema

### DIFF
--- a/src/schema/contract.schema.json
+++ b/src/schema/contract.schema.json
@@ -8,6 +8,9 @@
     "name": {
       "type": "string"
     },
+    "desc": {
+      "type": "string"
+    },
     "methods": {
       "type": "array",
       "items": {


### PR DESCRIPTION
The schema was missing the optional `desc` top-level key