### PR TITLE
fix: Add readonly and events to contract schema

### DIFF
--- a/src/schema/application.d.ts
+++ b/src/schema/application.d.ts
@@ -126,7 +126,6 @@ export interface CallConfig {
   close_out?: CallConfigValue;
   update_application?: CallConfigValue;
   delete_application?: CallConfigValue;
-  [k: string]: unknown;
 }
 export interface AppSources {
   approval?: string;

--- a/src/schema/application.d.ts
+++ b/src/schema/application.d.ts
@@ -21,6 +21,7 @@ export type DefaultArgument =
        */
       source: "abi-method";
       data: ContractMethod;
+      [k: string]: unknown;
     }
   | {
       /**
@@ -31,6 +32,7 @@ export type DefaultArgument =
        * The key of the state variable
        */
       data: string;
+      [k: string]: unknown;
     }
   | {
       /**
@@ -41,6 +43,7 @@ export type DefaultArgument =
        * The key of the state variable
        */
       data: string;
+      [k: string]: unknown;
     }
   | {
       /**
@@ -51,6 +54,7 @@ export type DefaultArgument =
        * The static default value to use.
        */
       data: string | number;
+      [k: string]: unknown;
     };
 export type CallConfigValue = "NEVER" | "CALL" | "CREATE" | "ALL";
 
@@ -63,6 +67,7 @@ export interface AlgoAppSpec {
   schema: SchemaSpec;
   state: StateSchemaSpec;
   bare_call_config?: CallConfig;
+  [k: string]: unknown;
 }
 export interface Hint {
   read_only?: boolean;
@@ -74,10 +79,12 @@ export interface Hint {
     [k: string]: DefaultArgument;
   };
   call_config?: CallConfig;
+  [k: string]: unknown;
 }
 export interface Struct {
   name: string;
   elements: StructElement[];
+  [k: string]: unknown;
 }
 /**
  * The contract of the ABI method to invoke.
@@ -92,7 +99,11 @@ export interface ContractMethod {
      * Catch all for fixed length arrays and tuples
      */
     type: string;
+    [k: string]: unknown;
   };
+  readonly?: boolean;
+  events?: Event[];
+  [k: string]: unknown;
 }
 export interface ContractMethodArg {
   desc?: string;
@@ -101,6 +112,13 @@ export interface ContractMethodArg {
    */
   type: string;
   name: string;
+  [k: string]: unknown;
+}
+export interface Event {
+  name: string;
+  args: ContractMethodArg[];
+  desc?: string;
+  [k: string]: unknown;
 }
 export interface CallConfig {
   no_op?: CallConfigValue;
@@ -108,20 +126,25 @@ export interface CallConfig {
   close_out?: CallConfigValue;
   update_application?: CallConfigValue;
   delete_application?: CallConfigValue;
+  [k: string]: unknown;
 }
 export interface AppSources {
   approval?: string;
   clear?: string;
+  [k: string]: unknown;
 }
 export interface AbiContract {
   name: string;
   desc?: string;
   methods: ContractMethod1[];
+  events?: Event[];
   networks?: {
     [k: string]: {
       appID: number;
+      [k: string]: unknown;
     };
   };
+  [k: string]: unknown;
 }
 export interface ContractMethod1 {
   name: string;
@@ -133,7 +156,11 @@ export interface ContractMethod1 {
      * Catch all for fixed length arrays and tuples
      */
     type: string;
+    [k: string]: unknown;
   };
+  readonly?: boolean;
+  events?: Event[];
+  [k: string]: unknown;
 }
 /**
  * The schema for global and local storage
@@ -141,6 +168,7 @@ export interface ContractMethod1 {
 export interface SchemaSpec {
   global?: Schema;
   local?: Schema;
+  [k: string]: unknown;
 }
 export interface Schema {
   declared?: {
@@ -149,6 +177,7 @@ export interface Schema {
   reserved?: {
     [k: string]: ReservedSchemaValueSpec;
   };
+  [k: string]: unknown;
 }
 export interface DeclaredSchemaValueSpec {
   /**
@@ -167,6 +196,7 @@ export interface DeclaredSchemaValueSpec {
    * Whether the value is set statically (at create time only) or dynamically
    */
   static?: boolean;
+  [k: string]: unknown;
 }
 export interface ReservedSchemaValueSpec {
   /**
@@ -186,8 +216,10 @@ export interface ReservedSchemaValueSpec {
 export interface StateSchemaSpec {
   global: StateSchema;
   local: StateSchema;
+  [k: string]: unknown;
 }
 export interface StateSchema {
   num_uints: number;
   num_byte_slices: number;
+  [k: string]: unknown;
 }

--- a/src/schema/application.schema.json
+++ b/src/schema/application.schema.json
@@ -191,7 +191,7 @@
     },
     "CallConfig": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "no_op": {
           "$ref": "#/definitions/CallConfigValue"

--- a/src/schema/application.schema.json
+++ b/src/schema/application.schema.json
@@ -2,8 +2,13 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "AlgoAppSpec",
   "type": "object",
-  "required": ["contract", "schema", "source", "state"],
-  "additionalProperties": false,
+  "required": [
+    "contract",
+    "schema",
+    "source",
+    "state"
+  ],
+  "additionalProperties": true,
   "properties": {
     "hints": {
       "type": "object",
@@ -30,12 +35,18 @@
   "definitions": {
     "AVMType": {
       "description": "AVM data type",
-      "enum": ["uint64", "bytes"]
+      "enum": [
+        "uint64",
+        "bytes"
+      ]
     },
     "DeclaredSchemaValueSpec": {
       "type": "object",
-      "required": ["type", "key"],
-      "additionalProperties": false,
+      "required": [
+        "type",
+        "key"
+      ],
+      "additionalProperties": true,
       "properties": {
         "type": {
           "description": "The type of the value",
@@ -57,7 +68,9 @@
     },
     "ReservedSchemaValueSpec": {
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "description": "The type of the value",
@@ -75,8 +88,11 @@
     },
     "StateSchemaSpec": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["global", "local"],
+      "additionalProperties": true,
+      "required": [
+        "global",
+        "local"
+      ],
       "properties": {
         "global": {
           "$ref": "#/definitions/StateSchema"
@@ -88,8 +104,11 @@
     },
     "StateSchema": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["num_byte_slices", "num_uints"],
+      "additionalProperties": true,
+      "required": [
+        "num_byte_slices",
+        "num_uints"
+      ],
       "properties": {
         "num_uints": {
           "type": "integer"
@@ -102,7 +121,7 @@
     "SchemaSpec": {
       "description": "The schema for global and local storage",
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "global": {
           "$ref": "#/definitions/Schema"
@@ -114,7 +133,7 @@
     },
     "Schema": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "declared": {
           "type": "object",
@@ -132,7 +151,7 @@
     },
     "AppSources": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "approval": {
           "type": "string"
@@ -144,7 +163,7 @@
     },
     "Hint": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "read_only": {
           "type": "boolean"
@@ -172,7 +191,7 @@
     },
     "CallConfig": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "no_op": {
           "$ref": "#/definitions/CallConfigValue"
@@ -192,12 +211,20 @@
       }
     },
     "CallConfigValue": {
-      "enum": ["NEVER", "CALL", "CREATE", "ALL"]
+      "enum": [
+        "NEVER",
+        "CALL",
+        "CREATE",
+        "ALL"
+      ]
     },
     "Struct": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "elements"],
+      "additionalProperties": true,
+      "required": [
+        "name",
+        "elements"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -233,12 +260,17 @@
       "oneOf": [
         {
           "type": "object",
-          "required": ["source", "data"],
-          "additionalProperties": false,
+          "required": [
+            "source",
+            "data"
+          ],
+          "additionalProperties": true,
           "properties": {
             "source": {
               "description": "The default value should be fetched by invoking an ABI method",
-              "enum": ["abi-method"]
+              "enum": [
+                "abi-method"
+              ]
             },
             "data": {
               "description": "The contract of the ABI method to invoke.",
@@ -248,12 +280,17 @@
         },
         {
           "type": "object",
-          "required": ["source", "data"],
-          "additionalProperties": false,
+          "required": [
+            "source",
+            "data"
+          ],
+          "additionalProperties": true,
           "properties": {
             "source": {
               "description": "The default value should be fetched from global state",
-              "enum": ["global-state"]
+              "enum": [
+                "global-state"
+              ]
             },
             "data": {
               "description": "The key of the state variable",
@@ -263,12 +300,17 @@
         },
         {
           "type": "object",
-          "required": ["source", "data"],
-          "additionalProperties": false,
+          "required": [
+            "source",
+            "data"
+          ],
+          "additionalProperties": true,
           "properties": {
             "source": {
               "description": "The default value should be fetched from the local state of the sender user",
-              "enum": ["local-state"]
+              "enum": [
+                "local-state"
+              ]
             },
             "data": {
               "description": "The key of the state variable",
@@ -278,12 +320,17 @@
         },
         {
           "type": "object",
-          "required": ["source", "data"],
-          "additionalProperties": false,
+          "required": [
+            "source",
+            "data"
+          ],
+          "additionalProperties": true,
           "properties": {
             "source": {
               "description": "The default value is a constant.",
-              "enum": ["constant"]
+              "enum": [
+                "constant"
+              ]
             },
             "data": {
               "description": "The static default value to use.",

--- a/src/schema/contract.schema.json
+++ b/src/schema/contract.schema.json
@@ -61,6 +61,9 @@
               "$ref": "#/definitions/ABIType"
             }
           }
+        },
+        "readonly": {
+          "type": "boolean"
         }
       }
     },

--- a/src/schema/contract.schema.json
+++ b/src/schema/contract.schema.json
@@ -2,7 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "AbiContract",
   "type": "object",
-  "required": ["name", "methods"],
+  "required": [
+    "name",
+    "methods"
+  ],
   "additionalProperties": false,
   "properties": {
     "name": {
@@ -17,11 +20,19 @@
         "$ref": "#/definitions/ContractMethod"
       }
     },
+    "events": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Event"
+      }
+    },
     "networks": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "required": ["appID"],
+        "required": [
+          "appID"
+        ],
         "additionalProperties": false,
         "properties": {
           "appID": {
@@ -35,7 +46,11 @@
     "ContractMethod": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "args", "returns"],
+      "required": [
+        "name",
+        "args",
+        "returns"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -52,7 +67,9 @@
         "returns": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["type"],
+          "required": [
+            "type"
+          ],
           "properties": {
             "desc": {
               "type": "string"
@@ -64,13 +81,44 @@
         },
         "readonly": {
           "type": "boolean"
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Event"
+          }
+        }
+      }
+    },
+    "Event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "args"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ContractMethodArg"
+          }
+        },
+        "desc": {
+          "type": "string"
         }
       }
     },
     "ContractMethodArg": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "type"],
+      "required": [
+        "name",
+        "type"
+      ],
       "properties": {
         "desc": {
           "type": "string"

--- a/src/schema/contract.schema.json
+++ b/src/schema/contract.schema.json
@@ -6,7 +6,7 @@
     "name",
     "methods"
   ],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "name": {
       "type": "string"
@@ -33,7 +33,7 @@
         "required": [
           "appID"
         ],
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "appID": {
             "type": "number"
@@ -45,7 +45,7 @@
   "definitions": {
     "ContractMethod": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "name",
         "args",
@@ -66,7 +66,7 @@
         },
         "returns": {
           "type": "object",
-          "additionalProperties": false,
+          "additionalProperties": true,
           "required": [
             "type"
           ],
@@ -92,7 +92,7 @@
     },
     "Event": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "name",
         "args"
@@ -114,7 +114,7 @@
     },
     "ContractMethodArg": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "name",
         "type"


### PR DESCRIPTION
Add readonly to the methods schema and events to contract and method schema because currently app specs with these fields will throw an error