### PR TITLE
feature: Allow options to be passed to simulate calls on the transaction composer, and properly type the return values.

### DIFF
--- a/examples/lifecycle/client.ts
+++ b/examples/lifecycle/client.ts
@@ -25,8 +25,8 @@ import type {
 } from '@algorandfoundation/algokit-utils/types/app-client'
 import type { AppSpec } from '@algorandfoundation/algokit-utils/types/app-spec'
 import type { SendTransactionResult, TransactionToSign, SendTransactionFrom } from '@algorandfoundation/algokit-utils/types/transaction'
-import type { ABIResult, TransactionWithSigner, modelsv2 } from 'algosdk'
-import { Algodv2, OnApplicationComplete, Transaction, AtomicTransactionComposer } from 'algosdk'
+import type { ABIResult, TransactionWithSigner } from 'algosdk'
+import { Algodv2, OnApplicationComplete, Transaction, AtomicTransactionComposer, modelsv2 } from 'algosdk'
 export const APP_SPEC: AppSpec = {
   "hints": {
     "hello(string)string": {
@@ -671,10 +671,13 @@ export class LifeCycleAppClient {
         await promiseChain
         return atc
       },
-      async simulate() {
+      async simulate(options?: SimulateOptions) {
         await promiseChain
-        const result = await atc.simulate(client.algod)
-        return result
+        const result = await atc.simulate(client.algod, new modelsv2.SimulateRequest({ txnGroups: [], ...options }))
+        return {
+          ...result,
+          returns: result.methodResults?.map((val, i) => resultMappers[i] !== undefined ? resultMappers[i]!(val.returnValue) : val.returnValue)
+        }
       },
       async execute() {
         await promiseChain
@@ -741,13 +744,15 @@ export type LifeCycleAppComposer<TReturns extends [...any[]] = []> = {
   /**
    * Simulates the transaction group and returns the result
    */
-  simulate(): Promise<LifeCycleAppComposerSimulateResult>
+  simulate(options?: SimulateOptions): Promise<LifeCycleAppComposerSimulateResult<TReturns>>
   /**
    * Executes the transaction group and returns the results
    */
   execute(): Promise<LifeCycleAppComposerResults<TReturns>>
 }
-export type LifeCycleAppComposerSimulateResult = {
+export type SimulateOptions = Omit<ConstructorParameters<typeof modelsv2.SimulateRequest>[0], 'txnGroups'>
+export type LifeCycleAppComposerSimulateResult<TReturns extends [...any[]]> = {
+  returns: TReturns
   methodResults: ABIResult[]
   simulateResponse: modelsv2.SimulateResponse
 }

--- a/src/client/call-composer-types.ts
+++ b/src/client/call-composer-types.ts
@@ -58,7 +58,7 @@ export function* callComposerType(ctx: GeneratorContext): DocumentParts {
   yield* jsDoc({
     description: 'Simulates the transaction group and returns the result',
   })
-  yield `simulate(): Promise<${name}ComposerSimulateResult>`
+  yield `simulate(options?: SimulateOptions): Promise<${name}ComposerSimulateResult<TReturns>>`
 
   yield* jsDoc({
     description: 'Executes the transaction group and returns the results',
@@ -66,9 +66,11 @@ export function* callComposerType(ctx: GeneratorContext): DocumentParts {
   yield `execute(): Promise<${name}ComposerResults<TReturns>>`
 
   yield DecIndentAndCloseBlock
+  yield `export type SimulateOptions = Omit<ConstructorParameters<typeof modelsv2.SimulateRequest>[0], 'txnGroups'>`
 
-  yield `export type ${name}ComposerSimulateResult = {`
+  yield `export type ${name}ComposerSimulateResult<TReturns extends [...any[]]> = {`
   yield IncIndent
+  yield `returns: TReturns`
   yield `methodResults: ABIResult[]`
   yield `simulateResponse: modelsv2.SimulateResponse`
   yield DecIndentAndCloseBlock

--- a/src/client/call-composer.ts
+++ b/src/client/call-composer.ts
@@ -39,11 +39,15 @@ export function* composeMethod(ctx: GeneratorContext): DocumentParts {
   yield DecIndent
   yield '},'
 
-  yield `async simulate() {`
+  yield `async simulate(options?: SimulateOptions) {`
   yield IncIndent
   yield `await promiseChain`
-  yield `const result = await atc.simulate(client.algod)`
-  yield `return result`
+  yield `const result = await atc.simulate(client.algod, new modelsv2.SimulateRequest({ txnGroups: [], ...options }))`
+  yield `return {`
+  yield IncIndent
+  yield `...result,`
+  yield `returns: result.methodResults?.map((val, i) => resultMappers[i] !== undefined ? resultMappers[i]!(val.returnValue) : val.returnValue)`
+  yield DecIndentAndCloseBlock
   yield DecIndent
   yield '},'
 

--- a/src/client/imports.ts
+++ b/src/client/imports.ts
@@ -22,6 +22,6 @@ import type {
 } from '@algorandfoundation/algokit-utils/types/app-client'
 import type { AppSpec } from '@algorandfoundation/algokit-utils/types/app-spec'
 import type { SendTransactionResult, TransactionToSign, SendTransactionFrom } from '@algorandfoundation/algokit-utils/types/transaction'
-import type { ABIResult, TransactionWithSigner, modelsv2 } from 'algosdk'
-import { Algodv2, OnApplicationComplete, Transaction, AtomicTransactionComposer } from 'algosdk'`
+import type { ABIResult, TransactionWithSigner } from 'algosdk'
+import { Algodv2, OnApplicationComplete, Transaction, AtomicTransactionComposer, modelsv2 } from 'algosdk'`
 }


### PR DESCRIPTION
…
## Proposed Changes

- When calling `.simluate()` on a transaction composer, you can now pass in options that are forwarded to the underlying `atc.simulate()` call. For example `client.someCall().simulate({ allowEmptySignatures: true })` 
- Simulate calls now have a `returns` property (similar to the `.execute()` response) containing mapped return values.
