### PR TITLE
fix: Include CoreAppCallArgs on abi op methods

### DIFF
--- a/examples/lifecycle/client.ts
+++ b/examples/lifecycle/client.ts
@@ -520,7 +520,7 @@ export class LifeCycleAppClient {
        * @param params Any additional parameters for the call
        * @returns The create result: The formatted greeting
        */
-      async createStringString(args: MethodArgs<'create(string)string'>, params: AppClientCallCoreParams & AppClientCompilationParams & IncludeSchema & (OnCompleteNoOp) = {}) {
+      async createStringString(args: MethodArgs<'create(string)string'>, params: AppClientCallCoreParams & AppClientCompilationParams & IncludeSchema & CoreAppCallArgs & (OnCompleteNoOp) = {}) {
         return $this.mapReturnValue<MethodReturn<'create(string)string'>, AppCreateCallTransactionResult>(await $this.appClient.create(LifeCycleAppCallFactory.create.createStringString(args, params)))
       },
       /**
@@ -530,7 +530,7 @@ export class LifeCycleAppClient {
        * @param params Any additional parameters for the call
        * @returns The create result
        */
-      async createStringUint32Void(args: MethodArgs<'create(string,uint32)void'>, params: AppClientCallCoreParams & AppClientCompilationParams & IncludeSchema & (OnCompleteNoOp) = {}) {
+      async createStringUint32Void(args: MethodArgs<'create(string,uint32)void'>, params: AppClientCallCoreParams & AppClientCompilationParams & IncludeSchema & CoreAppCallArgs & (OnCompleteNoOp) = {}) {
         return $this.mapReturnValue<MethodReturn<'create(string,uint32)void'>, AppCreateCallTransactionResult>(await $this.appClient.create(LifeCycleAppCallFactory.create.createStringUint32Void(args, params)))
       },
     }

--- a/examples/state/client.ts
+++ b/examples/state/client.ts
@@ -1157,7 +1157,7 @@ export class StateAppClient {
        * @param params Any additional parameters for the call
        * @returns The create result
        */
-      async createAbi(args: MethodArgs<'create_abi(string)string'>, params: AppClientCallCoreParams & AppClientCompilationParams & IncludeSchema & (OnCompleteNoOp) = {}) {
+      async createAbi(args: MethodArgs<'create_abi(string)string'>, params: AppClientCallCoreParams & AppClientCompilationParams & IncludeSchema & CoreAppCallArgs & (OnCompleteNoOp) = {}) {
         return $this.mapReturnValue<MethodReturn<'create_abi(string)string'>, AppCreateCallTransactionResult>(await $this.appClient.create(StateAppCallFactory.create.createAbi(args, params)))
       },
     }
@@ -1185,7 +1185,7 @@ export class StateAppClient {
        * @param params Any additional parameters for the call
        * @returns The update result
        */
-      async updateAbi(args: MethodArgs<'update_abi(string)string'>, params: AppClientCallCoreParams & AppClientCompilationParams = {}) {
+      async updateAbi(args: MethodArgs<'update_abi(string)string'>, params: AppClientCallCoreParams & AppClientCompilationParams & CoreAppCallArgs = {}) {
         return $this.mapReturnValue<MethodReturn<'update_abi(string)string'>, AppUpdateCallTransactionResult>(await $this.appClient.update(StateAppCallFactory.update.updateAbi(args, params)))
       },
     }
@@ -1213,7 +1213,7 @@ export class StateAppClient {
        * @param params Any additional parameters for the call
        * @returns The delete result
        */
-      async deleteAbi(args: MethodArgs<'delete_abi(string)string'>, params: AppClientCallCoreParams = {}) {
+      async deleteAbi(args: MethodArgs<'delete_abi(string)string'>, params: AppClientCallCoreParams & CoreAppCallArgs = {}) {
         return $this.mapReturnValue<MethodReturn<'delete_abi(string)string'>>(await $this.appClient.delete(StateAppCallFactory.delete.deleteAbi(args, params)))
       },
     }
@@ -1232,7 +1232,7 @@ export class StateAppClient {
        * @param params Any additional parameters for the call
        * @returns The optIn result
        */
-      async optIn(args: MethodArgs<'opt_in()void'>, params: AppClientCallCoreParams = {}) {
+      async optIn(args: MethodArgs<'opt_in()void'>, params: AppClientCallCoreParams & CoreAppCallArgs = {}) {
         return $this.mapReturnValue<MethodReturn<'opt_in()void'>>(await $this.appClient.optIn(StateAppCallFactory.optIn.optIn(args, params)))
       },
     }

--- a/examples/voting/client.ts
+++ b/examples/voting/client.ts
@@ -722,7 +722,7 @@ export class VotingRoundAppClient {
        * @param params Any additional parameters for the call
        * @returns The create result
        */
-      async create(args: MethodArgs<'create(string,byte[],string,uint64,uint64,uint8[],uint64,string)void'>, params: AppClientCallCoreParams & AppClientCompilationParams & IncludeSchema & (OnCompleteNoOp) = {}) {
+      async create(args: MethodArgs<'create(string,byte[],string,uint64,uint64,uint8[],uint64,string)void'>, params: AppClientCallCoreParams & AppClientCompilationParams & IncludeSchema & CoreAppCallArgs & (OnCompleteNoOp) = {}) {
         return $this.mapReturnValue<MethodReturn<'create(string,byte[],string,uint64,uint64,uint8[],uint64,string)void'>, AppCreateCallTransactionResult>(await $this.appClient.create(VotingRoundAppCallFactory.create.create(args, params)))
       },
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7146,9 +7146,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.5.0.tgz",
-      "integrity": "sha512-Ejxwvfh9YnWVU2yA5FzoYLTW52vxHCz+MHrOFg9Cc8IFgF/6f5AGPAvb5WTay5DIUP1NIfN3VBZ0cLlGO0Ys+A==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.5.1.tgz",
+      "integrity": "sha512-RozZuGuWbbhDM2sRhOSLIRb3DLyof6TREi0TW5b3xUEBropDhDqEHv0iAjA1zsIwXKgfIkR8GvQMd4oeKKg9eQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -7157,6 +7157,7 @@
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
         "@npmcli/promise-spawn",
+        "@npmcli/redact",
         "@npmcli/run-script",
         "@sigstore/tuf",
         "abbrev",
@@ -7222,13 +7223,6 @@
         "write-file-atomic"
       ],
       "dev": true,
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^7.2.1",
@@ -7237,23 +7231,24 @@
         "@npmcli/map-workspaces": "^3.0.4",
         "@npmcli/package-json": "^5.0.0",
         "@npmcli/promise-spawn": "^7.0.1",
+        "@npmcli/redact": "^1.1.0",
         "@npmcli/run-script": "^7.0.4",
-        "@sigstore/tuf": "^2.3.1",
+        "@sigstore/tuf": "^2.3.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
         "cacache": "^18.0.2",
         "chalk": "^5.3.0",
         "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.3",
+        "cli-table3": "^0.6.4",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.3.10",
+        "glob": "^10.3.12",
         "graceful-fs": "^4.2.11",
         "hosted-git-info": "^7.0.1",
-        "ini": "^4.1.1",
-        "init-package-json": "^6.0.0",
+        "ini": "^4.1.2",
+        "init-package-json": "^6.0.2",
         "is-cidr": "^5.0.3",
         "json-parse-even-better-errors": "^3.0.1",
         "libnpmaccess": "^8.0.1",
@@ -7268,11 +7263,11 @@
         "libnpmteam": "^6.0.0",
         "libnpmversion": "^5.0.1",
         "make-fetch-happen": "^13.0.0",
-        "minimatch": "^9.0.3",
+        "minimatch": "^9.0.4",
         "minipass": "^7.0.4",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^10.0.1",
+        "node-gyp": "^10.1.0",
         "nopt": "^7.2.0",
         "normalize-package-data": "^6.0.0",
         "npm-audit-report": "^5.0.0",
@@ -7280,7 +7275,7 @@
         "npm-package-arg": "^11.0.1",
         "npm-pick-manifest": "^9.0.0",
         "npm-profile": "^9.0.0",
-        "npm-registry-fetch": "^16.1.0",
+        "npm-registry-fetch": "^16.2.0",
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
@@ -7288,12 +7283,12 @@
         "parse-conflict-json": "^3.0.1",
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.1.0",
+        "read": "^3.0.1",
         "semver": "^7.6.0",
         "spdx-expression-parse": "^3.0.1",
         "ssri": "^10.0.5",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
@@ -7597,7 +7592,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "7.4.0",
+      "version": "7.4.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7618,12 +7613,12 @@
         "hosted-git-info": "^7.0.1",
         "json-parse-even-better-errors": "^3.0.0",
         "json-stringify-nice": "^1.1.4",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.4",
         "nopt": "^7.0.0",
         "npm-install-checks": "^6.2.0",
         "npm-package-arg": "^11.0.1",
         "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
+        "npm-registry-fetch": "^16.2.0",
         "npmlog": "^7.0.1",
         "pacote": "^17.0.4",
         "parse-conflict-json": "^3.0.0",
@@ -7644,14 +7639,14 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "8.2.0",
+      "version": "8.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.2",
         "ci-info": "^4.0.0",
-        "ini": "^4.1.0",
+        "ini": "^4.1.2",
         "nopt": "^7.0.0",
         "proc-log": "^3.0.0",
         "read-package-json-fast": "^3.0.2",
@@ -7826,6 +7821,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/redact": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "7.0.4",
       "dev": true,
@@ -7898,7 +7902,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -7956,7 +7960,7 @@
       }
     },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8044,12 +8048,15 @@
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
@@ -8164,7 +8171,7 @@
       }
     },
     "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8442,16 +8449,16 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.3.10",
+      "version": "10.3.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
+        "jackspeak": "^2.3.6",
         "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "minipass": "^7.0.4",
+        "path-scurry": "^1.10.2"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
@@ -8575,7 +8582,7 @@
       }
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "4.1.1",
+      "version": "4.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8584,15 +8591,15 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/package-json": "^5.0.0",
         "npm-package-arg": "^11.0.0",
         "promzard": "^1.0.0",
-        "read": "^2.0.0",
-        "read-package-json": "^7.0.0",
+        "read": "^3.0.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^5.0.0"
@@ -8741,20 +8748,20 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^16.2.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "6.0.7",
+      "version": "6.0.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8762,19 +8769,19 @@
         "@npmcli/arborist": "^7.2.1",
         "@npmcli/disparity-colors": "^3.0.0",
         "@npmcli/installed-package-contents": "^2.0.2",
-        "binary-extensions": "^2.2.0",
+        "binary-extensions": "^2.3.0",
         "diff": "^5.1.0",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.4",
         "npm-package-arg": "^11.0.1",
         "pacote": "^17.0.4",
-        "tar": "^6.2.0"
+        "tar": "^6.2.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "7.0.8",
+      "version": "7.0.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8786,7 +8793,7 @@
         "npmlog": "^7.0.1",
         "pacote": "^17.0.4",
         "proc-log": "^3.0.0",
-        "read": "^2.0.0",
+        "read": "^3.0.1",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
         "walk-up-path": "^3.0.1"
@@ -8796,7 +8803,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8808,33 +8815,33 @@
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "10.0.1",
+      "version": "10.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^16.2.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^16.2.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "6.0.7",
+      "version": "6.0.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8849,7 +8856,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "9.0.4",
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8857,7 +8864,7 @@
         "ci-info": "^4.0.0",
         "normalize-package-data": "^6.0.0",
         "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0",
+        "npm-registry-fetch": "^16.2.0",
         "proc-log": "^3.0.0",
         "semver": "^7.3.7",
         "sigstore": "^2.2.0",
@@ -8868,25 +8875,25 @@
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^16.2.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^16.2.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -8940,7 +8947,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.3",
+      "version": "9.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9148,7 +9155,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "10.0.1",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9299,11 +9306,12 @@
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "16.1.0",
+      "version": "16.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/redact": "^1.1.0",
         "make-fetch-happen": "^13.0.0",
         "minipass": "^7.0.2",
         "minipass-fetch": "^3.0.0",
@@ -9411,12 +9419,12 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
@@ -9486,12 +9494,12 @@
       }
     },
     "node_modules/npm/node_modules/promzard": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "^2.0.0"
+        "read": "^3.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9506,12 +9514,12 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "2.1.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "~1.0.0"
+        "mute-stream": "^1.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9802,7 +9810,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/src/client/call-client.ts
+++ b/src/client/call-client.ts
@@ -204,7 +204,7 @@ function* operationMethod(
           includeCompilation ? ' & AppClientCompilationParams' : ''
         }${
           includeSchema ? ' & IncludeSchema' : ''
-        }${onComplete?.type ? ` & ${onComplete.type}` : ''}${onComplete?.isOptional !== false ? ' = {}' : ''}) {`
+        } & CoreAppCallArgs${onComplete?.type ? ` & ${onComplete.type}` : ''}${onComplete?.isOptional !== false ? ' = {}' : ''}) {`
         yield* indent(
           `return $this.mapReturnValue<MethodReturn<'${methodSigSafe}'>${responseTypeGenericParam}>(await $this.appClient.${verb}(${name}CallFactory.${verb}${methodNameAccessor}(args, params)))`,
         )


### PR DESCRIPTION
## Proposed Changes

- ABI op methods (non-bare calls) were missing the `CoreAppCallArgs` type in their params. This PR adds it in
