### PR TITLE
fix: input type for uintN[], N > 51

### DIFF
--- a/src/client/helpers/get-equivalent-type.ts
+++ b/src/client/helpers/get-equivalent-type.ts
@@ -38,7 +38,13 @@ export function getEquivalentType(abiTypeStr: string, ioType: 'input' | 'output'
     }
     if (abiType instanceof ABIArrayDynamicType) {
       if (abiType.childType instanceof ABIByteType) return 'Uint8Array'
-      return `${abiTypeToTs(abiType.childType, ioType)}[]`
+
+      const childTsType = abiTypeToTs(abiType.childType, ioType)
+      if (childTsType === 'bigint | number') {
+        return 'bigint[] | number[]'
+      }
+
+      return `${childTsType}[]`
     }
     if (abiType instanceof ABIArrayStaticType) {
       if (abiType.childType instanceof ABIByteType) return 'Uint8Array'


### PR DESCRIPTION
## Proposed Changes

- Input types for large `uintN[]` are `bigint | number[]`. This PR fixes it so it's correctly `bigint[] | number[]`


Fixes #118 