### PR TITLE
fix: add utils-ts types imports to externals list in rollup config

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -27,7 +27,7 @@ const config: RollupOptions = {
     moduleSideEffects: false,
     propertyReadSideEffects: false,
   },
-  external: [...Object.keys(pkg.dependencies)],
+  external: [...Object.keys(pkg.dependencies), /^@algorandfoundation\/algokit-utils\/types\/*/],
   plugins: [
     typescript({
       tsconfig: 'tsconfig.build.json',


### PR DESCRIPTION
Rollup output for the latest beta package has the incorrect structure due to rollup not detecting the utils-ts type imports as externals.