### PR TITLE
chore: fix rollup build on node22

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build:2-lint": "eslint \"src/**/*.ts\" \"examples/**/*.spec.ts\" --max-warnings 0",
     "build:3-check-types": "tsc -p tsconfig.json",
     "build:4-check-types-non-strict": "tsc -p tsconfig.non-strict.json",
-    "build:5-build": "rollup -c --configPlugin typescript",
+    "build:5-build": "rollup -c --configPlugin typescript --configImportAttributesKey with",
     "build:6-copy-pkg-json": "npx --yes @makerx/ts-toolkit@4.0.0-beta.22 copy-package-json --input-folder ./ --output-folder ./dist --main index.js --types index.d.ts --custom-sections module type ",
     "build:7-copy-bin": "copyfiles bin/* dist/bin -f",
     "build:8-copy-readme": "copyfiles ./README.md ./dist",


### PR DESCRIPTION
When building using node22 the following error occurs [!] SyntaxError: Unexpected identifier 'assert' error.
Details: https://github.com/rollup/rollup/issues/5531