### PR TITLE
feat: add support for generating a minimal client

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,14 @@ export function cli(workingDirectory: string, args: string[]) {
     .requiredOption('-a --application <path>', 'Specifies the application.json file')
     .requiredOption('-o --output <path>', 'Specifies the output file path')
     .option('--pn --preserve-names', 'Preserve names from application.json spec instead of sanitizing them')
-    .addOption(new Option('-m --mode <mode>', 'Generate client in specified mode.').choices(generateModes).default('full'))
+    .addOption(
+      new Option(
+        '-m --mode <mode>',
+        "Generate client in specified mode. The 'full' mode includes all features, 'minimal' generates a smaller client without deployment features.",
+      )
+        .choices(generateModes)
+        .default('full'),
+    )
     .allowExcessArguments(true) // Maintains backwards compatibility with pre 13 commanded
     .action(
       async ({

--- a/src/client/generate.ts
+++ b/src/client/generate.ts
@@ -22,7 +22,7 @@ function convertStructs(s: StructField[], sanitizer: Sanitizer): StructField[] {
 }
 
 function shrinkAppSpec(app: Arc56Contract, options: GeneratorOptions): Arc56Contract {
-  const strippedApp = structuredClone(app)
+  const strippedAppSpec = structuredClone(app)
 
   // Only keep the source info if it is needed for error mapping
   const shrinkSourceInfo = (sourceInfo: ProgramSourceInfo['sourceInfo']) => {
@@ -37,34 +37,34 @@ function shrinkAppSpec(app: Arc56Contract, options: GeneratorOptions): Arc56Cont
   }
 
   // Keep only source info entries that can be used for approval and clear program error mapping
-  if (strippedApp.sourceInfo?.approval?.sourceInfo && strippedApp.sourceInfo.approval.sourceInfo.length > 0) {
-    strippedApp.sourceInfo.approval.sourceInfo = shrinkSourceInfo(strippedApp.sourceInfo.approval.sourceInfo)
+  if (strippedAppSpec.sourceInfo?.approval?.sourceInfo && strippedAppSpec.sourceInfo.approval.sourceInfo.length > 0) {
+    strippedAppSpec.sourceInfo.approval.sourceInfo = shrinkSourceInfo(strippedAppSpec.sourceInfo.approval.sourceInfo)
   }
 
-  if (strippedApp.sourceInfo?.clear?.sourceInfo && strippedApp.sourceInfo.clear.sourceInfo.length > 0) {
-    strippedApp.sourceInfo.clear.sourceInfo = shrinkSourceInfo(strippedApp.sourceInfo.clear.sourceInfo)
+  if (strippedAppSpec.sourceInfo?.clear?.sourceInfo && strippedAppSpec.sourceInfo.clear.sourceInfo.length > 0) {
+    strippedAppSpec.sourceInfo.clear.sourceInfo = shrinkSourceInfo(strippedAppSpec.sourceInfo.clear.sourceInfo)
   }
 
-  if (strippedApp.compilerInfo) {
-    delete strippedApp.compilerInfo
+  if (strippedAppSpec.compilerInfo) {
+    delete strippedAppSpec.compilerInfo
   }
 
   // These are used for deploying but not for calling deployed apps
   if (options.mode === 'minimal') {
-    if (strippedApp.source) {
-      delete strippedApp.source
+    if (strippedAppSpec.source) {
+      delete strippedAppSpec.source
     }
-    if (strippedApp.byteCode) {
-      delete strippedApp.byteCode
+    if (strippedAppSpec.byteCode) {
+      delete strippedAppSpec.byteCode
     }
-    if (strippedApp.templateVariables) {
-      delete strippedApp.templateVariables
+    if (strippedAppSpec.templateVariables) {
+      delete strippedAppSpec.templateVariables
     }
-    if (strippedApp.scratchVariables) {
-      delete strippedApp.scratchVariables
+    if (strippedAppSpec.scratchVariables) {
+      delete strippedAppSpec.scratchVariables
     }
   }
-  return strippedApp
+  return strippedAppSpec
 }
 
 export function* generate(app: Arc56Contract, options?: Partial<GeneratorOptions>): DocumentParts {


### PR DESCRIPTION
Adds a minimal mode, which can be leveraged to produce a stripped back client with a smaller file size.

I have also made a few additional changes:

Shrunk the app spec on a full client generation to reduce full client file size.
Fixed the temporarily ignored security issue (now there is a fix available)
Refactored the dev client generation process to be more maintainable
Extended the snapshot tests to ensure variations between modes are expected
Using the Reti and NFD clients as an example, the file size results are:

Reti
Previous Full: 764KB
New Full: 483KB (36.8% smaller)
New Minimal: 273KB (64.3% smaller)

NFD
Previous Full: 645KB
New Full: 377KB (41.6% smaller)
New Minimal: 143KB (77.8% smaller)