### PR TITLE
Use original struct name in *FromTuple functions

### DIFF
--- a/examples/smart_contracts/artifacts/arc56_test/client.minimal.ts
+++ b/examples/smart_contracts/artifacts/arc56_test/client.minimal.ts
@@ -65,7 +65,7 @@ export type FooUint16BarUint16 = {
  * Converts the ABI tuple representation of a { foo: uint16; bar: uint16 } to the struct representation
  */
 export function FooUint16BarUint16FromTuple(abiTuple: [number, number]) {
-  const abiStructType = ABIStructType.fromStruct('FooUint16BarUint16', APP_SPEC.structs)
+  const abiStructType = ABIStructType.fromStruct('{ foo: uint16; bar: uint16 }', APP_SPEC.structs)
   return getStructValueFromTupleValue(abiStructType, abiTuple) as FooUint16BarUint16
 }
 

--- a/examples/smart_contracts/artifacts/arc56_test/client.pn.ts
+++ b/examples/smart_contracts/artifacts/arc56_test/client.pn.ts
@@ -65,7 +65,7 @@ export type _foo_uint16_bar_uint16_ = {
  * Converts the ABI tuple representation of a { foo: uint16; bar: uint16 } to the struct representation
  */
 export function _foo_uint16_bar_uint16_FromTuple(abiTuple: [number, number]) {
-  const abiStructType = ABIStructType.fromStruct('_foo_uint16_bar_uint16_', APP_SPEC.structs)
+  const abiStructType = ABIStructType.fromStruct('{ foo: uint16; bar: uint16 }', APP_SPEC.structs)
   return getStructValueFromTupleValue(abiStructType, abiTuple) as _foo_uint16_bar_uint16_
 }
 

--- a/examples/smart_contracts/artifacts/arc56_test/client.spec.ts
+++ b/examples/smart_contracts/artifacts/arc56_test/client.spec.ts
@@ -7,6 +7,35 @@ import invariant from 'tiny-invariant'
 import { generateModes } from '../../../../src/client/generator-context'
 import { algorandFixture } from '@algorandfoundation/algokit-utils/testing'
 
+describe('struct FromTuple functions', () => {
+  test('FooUint16BarUint16FromTuple converts tuple to struct correctly', () => {
+    const tuple: [number, number] = [13, 37]
+    const result = full.FooUint16BarUint16FromTuple(tuple)
+
+    expect(result).toEqual({ foo: 13, bar: 37 })
+  })
+
+  test('OutputsFromTuple converts tuple to struct correctly', () => {
+    const tuple: [bigint, bigint] = [100n, 50n]
+    const result = full.OutputsFromTuple(tuple)
+
+    expect(result).toEqual({ sum: 100n, difference: 50n })
+  })
+
+  test('InputsFromTuple converts tuple to struct correctly', () => {
+    const tuple: [[bigint, bigint], [bigint, bigint]] = [
+      [1n, 2n],
+      [10n, 5n],
+    ]
+    const result = full.InputsFromTuple(tuple)
+
+    expect(result).toEqual({
+      add: { a: 1n, b: 2n },
+      subtract: { a: 10n, b: 5n },
+    })
+  })
+})
+
 describe('state typed client', () => {
   const localnet = algorandFixture()
 

--- a/examples/smart_contracts/artifacts/arc56_test/client.ts
+++ b/examples/smart_contracts/artifacts/arc56_test/client.ts
@@ -65,7 +65,7 @@ export type FooUint16BarUint16 = {
  * Converts the ABI tuple representation of a { foo: uint16; bar: uint16 } to the struct representation
  */
 export function FooUint16BarUint16FromTuple(abiTuple: [number, number]) {
-  const abiStructType = ABIStructType.fromStruct('FooUint16BarUint16', APP_SPEC.structs)
+  const abiStructType = ABIStructType.fromStruct('{ foo: uint16; bar: uint16 }', APP_SPEC.structs)
   return getStructValueFromTupleValue(abiStructType, abiTuple) as FooUint16BarUint16
 }
 

--- a/src/client/app-types.ts
+++ b/src/client/app-types.ts
@@ -210,7 +210,7 @@ function* structTypes(ctx: GeneratorContext): DocumentParts {
     // Emit method that converts ABI tuple to the struct object
     yield* jsDoc(`Converts the ABI tuple representation of a ${structName} to the struct representation`)
     yield* inline(`export function ${sanitizer.makeSafeTypeIdentifier(structName)}FromTuple(`, `abiTuple: ${structCtx.tsTupDef}`, `) {`)
-    yield* indent(`const abiStructType = ABIStructType.fromStruct('${sanitizer.makeSafeTypeIdentifier(structName)}', APP_SPEC.structs)`)
+    yield* indent(`const abiStructType = ABIStructType.fromStruct('${structName}', APP_SPEC.structs)`)
     yield* indent(`return getStructValueFromTupleValue(abiStructType, abiTuple) as ${sanitizer.makeSafeTypeIdentifier(structName)}`)
     yield '}'
     yield NewLine


### PR DESCRIPTION
## Proposed Changes

Use original struct name in *FromTuple functions

The ABIStructType.fromStruct() call was incorrectly using the sanitized
type identifier instead of the original struct name from the ARC-56 spec.
This caused lookup failures for structs with special characters in their
names like "{ foo: uint16; bar: uint16 }".

Added tests for all *FromTuple conversion functions.
