### PR TITLE
Ignore tar audit

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -8,5 +8,10 @@
     "active": true,
     "notes": "@semantic-release/npm with patched undici version not available yet",
     "expiry": "2026-02-15"
+  },
+  "1112659": {
+    "active": true,
+    "notes": "tar vulnerability in bundled npm package, cannot be overridden",
+    "expiry": "2026-02-15"
   }
 }


### PR DESCRIPTION
## Proposed Changes

- Ignore tar audit because tar is bundled in npm, wait for the fix from npm.
