### PR TITLE
Add repository url to package.json for npm provenance verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "src/index.js",
   "module": "index.mjs",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/algorandfoundation/algokit-client-generator-ts"
+  },
   "engines": {
     "node": ">=24.0"
   },


### PR DESCRIPTION
## Summary                
                             
Add `repository` field to `package.json` so npm's sigstore provenance verification can match the package to the GitHub repo during OIDC-based publishing