### PR TITLE
Bump algokit-utils to 10.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "algokitgen": "bin/cli.mjs"
       },
       "devDependencies": {
-        "@algorandfoundation/algokit-utils": "^10.0.0-alpha.41",
+        "@algorandfoundation/algokit-utils": "^10.0.0-beta.1",
         "@algorandfoundation/tealscript": "^0.107.0",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
@@ -53,7 +53,7 @@
         "node": ">=24.0"
       },
       "peerDependencies": {
-        "@algorandfoundation/algokit-utils": "^10.0.0-alpha.41"
+        "@algorandfoundation/algokit-utils": "^10.0.0-beta.1"
       }
     },
     "node_modules/@actions/core": {
@@ -106,13 +106,14 @@
       "license": "MIT"
     },
     "node_modules/@algorandfoundation/algokit-utils": {
-      "version": "10.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-10.0.0-alpha.41.tgz",
-      "integrity": "sha512-sFxfmxSTbMt5CinHlglzmru2L0ZEvnhQ/1LxwN2FYCKCYQNFBS+G5AsOYc+HfIpPMAPY390S3d0kAwIVFbqyrw==",
+      "version": "10.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@algorandfoundation/algokit-utils/-/algokit-utils-10.0.0-beta.1.tgz",
+      "integrity": "sha512-ShiMGqUHdhpQAG0JCkhFnVN9NRDd4IwXAOW8yIY1xoG/1tjjbrS9qaSxIxmCPLhOgFrePFmT6Wc/PT9pMjs7pQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algorandfoundation/xhd-wallet-api": "2.0.0-canary.1",
+        "@noble/curves": "^2.0.1",
         "@noble/ed25519": "^3.0.0",
         "@noble/hashes": "^2.0.1",
         "algorand-msgpack": "^1.1.0",
@@ -124,7 +125,7 @@
         "vlq": "^2.0.4"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=24.0"
       }
     },
     "node_modules/@algorandfoundation/algokit-utils/node_modules/@noble/ed25519": {

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "jsonschema": "^1.5.0"
   },
   "peerDependencies": {
-    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.41"
+    "@algorandfoundation/algokit-utils": "^10.0.0-beta.1"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.41",
+    "@algorandfoundation/algokit-utils": "^10.0.0-beta.1",
     "@algorandfoundation/tealscript": "^0.107.0",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",


### PR DESCRIPTION
## Summary

Upgrade `@algorandfoundation/algokit-utils` peer and dev dependency from `^10.0.0-alpha.41` to `^10.0.0-beta.1`